### PR TITLE
remove deprecation warning options issue #10

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -3,10 +3,7 @@ const mongoose = require('mongoose');
 mongoose.Promise = global.Promise;
 const connectDB = async () => {
     try {
-        await mongoose.connect(process.env.DATABASE_URL, {
-            useNewUrlParser: true,
-            useUnifiedTopology: true,
-        });
+        await mongoose.connect(process.env.DATABASE_URL);
 
         console.log("MongoDB connected...");
     } catch (err) {


### PR DESCRIPTION
## Issue {#10}

I have removed the deprecation warning options.
line 6 to 9 
```
await mongoose.connect(process.env.DATABASE_URL, {
            useNewUrlParser: true,
            useUnifiedTopology: true,
        });
```
will be changed to 
```
        await mongoose.connect(process.env.DATABASE_URL);
```
